### PR TITLE
Don't expand SCEVs with multiplication by non-constants

### DIFF
--- a/include/llvm_seahorn/Loops/SeaSCEVUtils.h
+++ b/include/llvm_seahorn/Loops/SeaSCEVUtils.h
@@ -1,0 +1,12 @@
+#ifndef LLVM_SEAHORN_SCEV_UTILS_H
+#define LLVM_SEAHORN_SCEV_UTILS_H
+
+namespace llvm {
+class SCEV;
+} // namespace llvm
+
+namespace llvm_seahorn {
+bool seaSCEVContainsMul(const llvm::SCEV *Expr);
+} // namespace llvm_seahorn
+
+#endif // LLVM_SEAHORN_SCEV_UTILS_H

--- a/lib/Transforms/Loops/CMakeLists.txt
+++ b/lib/Transforms/Loops/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_llvm_library(SeaLoops
   IndVarSimplify.cc
-  FakeLatchExit
+  FakeLatchExit.cc
+  SeaSCEVUtils.cc
 )

--- a/lib/Transforms/Loops/IndVarSimplify.cc
+++ b/lib/Transforms/Loops/IndVarSimplify.cc
@@ -53,6 +53,9 @@
 #include "llvm/Transforms/Utils/Local.h"
 #include "llvm/Transforms/Utils/LoopUtils.h"
 #include "llvm/Transforms/Utils/SimplifyIndVar.h"
+
+#include "llvm_seahorn/Loops/SeaSCEVUtils.h"
+
 using namespace llvm;
 
 #define DEBUG_TYPE "indvars"
@@ -625,6 +628,15 @@ void SeaIndVarSimplify::rewriteLoopExitValues(Loop *L, SCEVExpander &Rewriter) {
         if (!SE->isLoopInvariant(ExitValue, L) ||
             !isSafeToExpand(ExitValue, *SE))
           continue;
+
+        DEBUG(dbgs() << "[sea-indvars] Exit value:\t");
+        DEBUG(ExitValue->dump());
+
+        if (seaSCEVContainsMul(ExitValue)) {
+          DEBUG(dbgs() << "[Sea-IndVarSimplify] Scev: " << ExitValue << "\n"
+                       << "contains multiplication, overriding bailing-out!\n");
+          continue;
+        }
 
         // Computing the value outside of the loop brings no benefit if :
         //  - it is definitely used inside the loop in a way which can not be

--- a/lib/Transforms/Loops/SeaSCEVUtils.cc
+++ b/lib/Transforms/Loops/SeaSCEVUtils.cc
@@ -1,0 +1,41 @@
+#include "llvm_seahorn/Loops/SeaSCEVUtils.h"
+
+#include "llvm/Analysis/ScalarEvolutionAliasAnalysis.h"
+
+namespace llvm_seahorn {
+
+bool seaSCEVContainsMul(const llvm::SCEV *Expr) {
+  using namespace llvm;
+  assert(Expr);
+
+  if (const auto *M = dyn_cast<SCEVMulExpr>(Expr)) {
+    // If not all multiplication operands are constants we consider
+    // multiplication costly for *verification*.
+    if (std::count_if(M->op_begin(), M->op_end(), [](const SCEV *C) {
+          return isa<SCEVConstant>(C);
+        }) < M->getNumOperands() - 1)
+      return true;
+  }
+
+  if (const auto *Cast = dyn_cast<SCEVCastExpr>(Expr))
+    return seaSCEVContainsMul(Cast->getOperand());
+
+  if (const auto *Nary = dyn_cast<SCEVNAryExpr>(Expr)) {
+    for (const auto *Op : Nary->operands())
+      if (seaSCEVContainsMul(Op))
+        return true;
+
+    return false;
+  }
+
+  if (const auto *Div = dyn_cast<SCEVUDivExpr>(Expr)) {
+    if (seaSCEVContainsMul(Div->getLHS()))
+      return true;
+    if (seaSCEVContainsMul(Div->getRHS()))
+      return true;
+  }
+
+  return false;
+}
+
+} // namespace llvm_seahorn


### PR DESCRIPTION
This only affects IndVar simplification. SCEVExpander is also used in StrengthReduction and LoopUnrolling, but I'm not sure if we want to 'patch' every use of it at once.