### PR TITLE
Fix comments for SCEV expander

### DIFF
--- a/lib/Transforms/Loops/IndVarSimplify.cc
+++ b/lib/Transforms/Loops/IndVarSimplify.cc
@@ -632,6 +632,10 @@ void SeaIndVarSimplify::rewriteLoopExitValues(Loop *L, SCEVExpander &Rewriter) {
         DEBUG(dbgs() << "[sea-indvars] Exit value:\t");
         DEBUG(ExitValue->dump());
 
+        // Note that this might not catch all cases with multi-level AddRecExpr
+        // in rare cases. SCEV expander tried to reuse as much existing
+        // instructions as possible, so this is difficult to check against and
+        // happens rarely in practice.
         if (seaSCEVContainsMul(ExitValue)) {
           DEBUG(dbgs() << "[Sea-IndVarSimplify] Scev: " << ExitValue << "\n"
                        << "contains multiplication, overriding bailing-out!\n");

--- a/lib/Transforms/Loops/SeaSCEVUtils.cc
+++ b/lib/Transforms/Loops/SeaSCEVUtils.cc
@@ -9,7 +9,7 @@ bool seaSCEVContainsMul(const llvm::SCEV *Expr) {
   assert(Expr);
 
   if (const auto *M = dyn_cast<SCEVMulExpr>(Expr)) {
-    // If not all multiplication operands are constants we consider
+    // If there is more than one non-constant SCEV subexpression we consider
     // multiplication costly for *verification*.
     if (std::count_if(M->op_begin(), M->op_end(), [](const SCEV *C) {
           return isa<SCEVConstant>(C);


### PR DESCRIPTION
Added more clarifying comments. Turns out it is possible to generate mul when a scev expression contains no multiplication, but the llvm's implementation tries very hard not to do that, and it's difficult to tell without actually doing the expansion.