### PR TITLE
fix(inst-combine): disables loads folded into phi nodes

### DIFF
--- a/include/llvm_seahorn/Transforms/InstCombine/SeaInstCombine.h
+++ b/include/llvm_seahorn/Transforms/InstCombine/SeaInstCombine.h
@@ -31,6 +31,7 @@ class SeaInstCombinePass : public PassInfoMixin<SeaInstCombinePass> {
   const bool AvoidBv;
   const bool AvoidUnsignedICmp;
   const bool AvoidIntToPtr;
+  const bool AvoidAliasing;
 
 public:
   static StringRef name() { return "SeaInstCombinePass"; }
@@ -38,11 +39,13 @@ public:
   explicit SeaInstCombinePass(bool ExpensiveCombines = true,
 			      bool AvoidBv = true,
 			      bool AvoidUnsignedICmp = true,
-			      bool AvoidIntToPtr = true);
+			      bool AvoidIntToPtr = true,
+			      bool AvoidAliasing = true);
   explicit SeaInstCombinePass(bool ExpensiveCombines, unsigned MaxIterations,
 			      bool AvoidBv,
 			      bool AvoidUnsignedICmp,
-			      bool AvoidIntToPtr);
+			      bool AvoidIntToPtr,
+			      bool AvoidAliasing);
 
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
@@ -58,6 +61,7 @@ class SeaInstructionCombiningPass : public FunctionPass {
   const bool AvoidBv;
   const bool AvoidUnsignedICmp;
   const bool AvoidIntToPtr;
+  const bool AvoidAliasing;
 
 public:
   static char ID; // Pass identification, replacement for typeid
@@ -65,12 +69,14 @@ public:
   explicit SeaInstructionCombiningPass(bool ExpensiveCombines = true,
 				       bool AvoidBv = true,
 				       bool AvoidUnsignedICmp = true,
-				       bool AvoidIntToPtr = true);
+				       bool AvoidIntToPtr = true,
+				       bool AvoidAliasing = true);
   explicit SeaInstructionCombiningPass(bool ExpensiveCombines,
 				       unsigned MaxIterations,
 				       bool AvoidBv,
 				       bool AvoidUnsignedICmp,
-				       bool AvoidIntToPtr);
+				       bool AvoidIntToPtr,
+				       bool AvoidAliasing);
 
   void getAnalysisUsage(AnalysisUsage &AU) const override;
   bool runOnFunction(Function &F) override;

--- a/lib/Transforms/InstCombine/InstCombineInternal.h
+++ b/lib/Transforms/InstCombine/InstCombineInternal.h
@@ -327,6 +327,8 @@ private:
   // Avoid generating IntToPtr instructions.
   // /Accessible with IC.seaAvoidIntToPtr().
   bool AvoidIntToPtr;
+  // Avoid transformations which introduce new aliasing.
+  bool AvoidAliasing;
 #endif
 
   AliasAnalysis *AA;
@@ -351,9 +353,10 @@ public:
   InstCombiner(InstCombineWorklist &Worklist, BuilderTy &Builder,
                bool MinimizeSize, bool ExpensiveCombines,
 #if 1 /* SEAHORN ADD */	       
-	       bool AvoidBv, bool AvoidUnsignedICmp, bool AvoidIntToPtr,
+               bool AvoidBv, bool AvoidUnsignedICmp, bool AvoidIntToPtr,
+               bool AvoidAliasing,
 #endif 	       
-	       AliasAnalysis *AA,
+               AliasAnalysis *AA,
                AssumptionCache &AC, TargetLibraryInfo &TLI, DominatorTree &DT,
                OptimizationRemarkEmitter &ORE, BlockFrequencyInfo *BFI,
                ProfileSummaryInfo *PSI, const DataLayout &DL, LoopInfo *LI)
@@ -361,6 +364,7 @@ public:
         ExpensiveCombines(ExpensiveCombines),
 #if 1 /* SEAHORN ADD */    
         AvoidBv(AvoidBv), AvoidUnsignedICmp(AvoidUnsignedICmp), AvoidIntToPtr(AvoidIntToPtr),
+        AvoidAliasing(AvoidAliasing),
 #endif     
         AA(AA), AC(AC), TLI(TLI), DT(DT),
         DL(DL), SQ(DL, &TLI, &DT, &AC), ORE(ORE), BFI(BFI), PSI(PSI), LI(LI) {}


### PR DESCRIPTION
This is the first transformation we have disabled to reduce aliasing. Therefore, I've added an AvoidAlisaing flag to toggle the change. The flag is fixed to true for now.