### PR TITLE
fix(IPO): Annotation2Metadata produces valid metadata

### DIFF
--- a/include/llvm_seahorn/IR/LLVMContext.h
+++ b/include/llvm_seahorn/IR/LLVMContext.h
@@ -6,7 +6,7 @@ namespace llvm_seahorn {
 // See llvm/include/llvm/IR/FixedMetadataKinds.def
 class LLVMContext {
 public:
-  static unsigned const MD_annotation;
+  static const char *MD_annotation;
 };
 } // namespace llvm_seahorn
 

--- a/lib/Transforms/IPO/Annotation2Metadata.cpp
+++ b/lib/Transforms/IPO/Annotation2Metadata.cpp
@@ -28,7 +28,7 @@ using namespace llvm;
 
 #define DEBUG_TYPE "annotation2metadata"
 
-unsigned const llvm_seahorn::LLVMContext::MD_annotation = 30;
+const char *llvm_seahorn::LLVMContext::MD_annotation = "sea.annotations";
 
 // In llvm-12 this is Instruction::addAnnotationMetadata.
 // See llvm/lib/IR/Metadata.cpp.


### PR DESCRIPTION
In an upstream version of llvm, there is a new ID number for annotation metadata. The ID isn't define in llvm10, so using it results in an 'Invalid ID' error. This commit fixes the bug by using a string identifier for the metadata (string identifiers need not be built into llvm).