### PR TITLE
refactor(instcombine): avoid unsigned icmp

### DIFF
--- a/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -2711,11 +2711,11 @@ Instruction *SeaInstCombinerImpl::foldICmpAddConstant(ICmpInst &Cmp,
     return new ICmpInst(ICmpInst::ICMP_SGT, X, ConstantInt::get(Ty, ~(*C2)));
 
   // (X + C2) >s C --> X <u (SMAX - C) (if C == C2 - 1)
-  if (Pred == CmpInst::ICMP_SGT && C == *C2 - 1)
+  if (!AvoidUnsignedICmp && Pred == CmpInst::ICMP_SGT && C == *C2 - 1)
     return new ICmpInst(ICmpInst::ICMP_ULT, X, ConstantInt::get(Ty, SMax - C));
 
   // (X + C2) <s C --> X >u (C ^ SMAX) (if C == C2)
-  if (Pred == CmpInst::ICMP_SLT && C == *C2)
+  if (!AvoidUnsignedICmp && Pred == CmpInst::ICMP_SLT && C == *C2)
     return new ICmpInst(ICmpInst::ICMP_UGT, X, ConstantInt::get(Ty, C ^ SMax));
 
   if (!Add->hasOneUse())


### PR DESCRIPTION
Found more code patterns that introduce unsigned icmp instructions For instance, given:

  %cmp3 = icmp sgt i32 %call2, -6
  %cmp4 = icmp slt i32 %call2, 100
  %spec.select = and i1 %cmp3, i1 %cmp4
  %land.ext = zext i1 %spec.select to i32
  call void @__CRAB_assume(i32 %land.ext)

instcombine was producing:

  %1 = add i32 %call2, 5
  %2 = icmp ult i32 %1, 105
  %land.ext = zext i1 %2 to i32
  call void @__CRAB_assume(i32 %land.ext)

From now on, if AvoidUnsignedICmp is enabled then this transformation does not take place because it replaces signed icmp with unsigned icmp.