### PR TITLE
ci: use absolute seaopt path for lit

### DIFF
--- a/.github/workflows/sea-transforms.yml
+++ b/.github/workflows/sea-transforms.yml
@@ -55,5 +55,8 @@ jobs:
         env:
           V: ${{ steps.llvm.outputs.version }}
         run: |
-          export SEAOPT=./build/bin/seaopt OPT="opt-$V" FILECHECK="FileCheck-$V"
+          # seaopt must be an absolute path: lit runs each test from its own
+          # Output/ dir, so a relative ./build path would not resolve.
+          export SEAOPT="$GITHUB_WORKSPACE/build/bin/seaopt"
+          export OPT="opt-$V" FILECHECK="FileCheck-$V"
           lit -v test/sea_transforms


### PR DESCRIPTION
lit runs each test from its Output/ dir, so a relative ./build path does not resolve. Use $GITHUB_WORKSPACE/build/bin/seaopt.