### PR TITLE
test: add -O2 pipeline test

### DIFF
--- a/test/sea_transforms/README.md
+++ b/test/sea_transforms/README.md
@@ -40,17 +40,33 @@ SeaHorn's LoopUnroll deliberately ignores the `llvm.loop.unroll.disable`
 metadata (it only logs "Forcing Loop Unroll despite disable metadata" where
 stock bails). Validated on LLVM 14.
 
-Two other loop customizations are **not** unit-tested here, by design:
+Two other loop customizations are **not** behaviorally unit-tested here, by
+design:
 
 - **IndVarSimplify disequality avoidance** (`sea-indvars`): SeaHorn preserves the
   `slt`/`ult` exit predicate where stock LFTR would emit `icmp ne`. On LLVM 14,
   stock `-indvars` is too conservative to perform that LFTR rewrite on ordinary
-  integer-counter loops, so any standalone test would pass *vacuously* without
-  exercising the patch. Re-evaluate on LLVM 15 (LFTR behavior may differ), or
-  cover it at the pipeline level.
+  integer-counter loops -- even through the full `-O2` pipeline -- so any test
+  asserting the divergence would pass *vacuously*. Re-evaluate on LLVM 15.
 - **LoopRotate aggressiveness** (`sea-loop-rotate`): not registered as a
   standalone legacy pass in `seaopt` (it is wired only through the pass-manager
-  pipeline), so it cannot be driven in isolation by this harness.
+  pipeline), so it cannot be driven in isolation; and at `-O2` a large header
+  either folds below the stock threshold or blocks rotation, so the aggressive
+  threshold has no observable effect to assert on LLVM 14.
+
+## Pipeline test
+
+`pipeline_o2.ll` runs the full SeaHorn `-O2` pipeline (`PassManagerBuilder`),
+which engages sea-instcombine *and* the sea loop passes:
+
+- **Behavioral**: `urem`-by-pow2 survives `seaopt -O2` but stock `opt -O2` folds
+  it to `and` -- proving the pipeline uses `createSeaInstructionCombiningPass`
+  rather than stock InstCombine (a wiring regression the single-pass tests miss).
+- **Smoke/verify**: a loop function drives sea-loop-rotate / sea-indvars /
+  sea-loop-unroll under `-O2`, and the verifier RUN line asserts the output is
+  well-formed. Since those passes have no assertable behavioral divergence on
+  LLVM 14 (see above), this is their coverage -- it catches crashes / malformed
+  IR (e.g. opaque-pointer breakage during the port), not a specific rewrite.
 
 ## Running
 

--- a/test/sea_transforms/pipeline_o2.ll
+++ b/test/sea_transforms/pipeline_o2.ll
@@ -1,0 +1,49 @@
+; Pipeline-level test: run the full SeaHorn -O2 pipeline (PassManagerBuilder),
+; which wires in sea-instcombine, the sea loop-rotate, sea-indvars and
+; sea-loop-unroll -- not a single pass in isolation.
+;
+; Two things are checked:
+;   - Behavioral: the SeaHorn instcombine is actually engaged in the pipeline.
+;     `urem` by a power of two survives `seaopt -O2`, whereas stock `opt -O2`
+;     folds it to `and`. This catches a wiring regression where the pipeline
+;     picks up stock InstCombine instead of createSeaInstructionCombiningPass().
+;   - Smoke/verify: @sum drives the loop passes (rotate / indvars / unroll) as
+;     part of -O2; the verifier RUN line asserts the whole pipeline output is
+;     well-formed. This is the only coverage of the sea loop-rotate and
+;     sea-indvars passes -- their *behavioral* divergence from stock is not
+;     observable on LLVM 14 (stock LFTR never emits the disequality, and large
+;     headers either fold away or block rotation), so this guards against
+;     crashes / malformed IR (e.g. opaque-pointer breakage during the port)
+;     rather than asserting a specific rewrite.
+;
+; RUN: %seaopt -O2 -S %s | %FileCheck %s
+; RUN: %seaopt -O2 -S %s | %opt -passes=verify -disable-output
+; RUN: %opt -O2 -S %s | %FileCheck --check-prefix=STOCK %s
+
+define i32 @urem_pow2(i32 %x) {
+  %r = urem i32 %x, 8
+  ret i32 %r
+}
+
+define i32 @sum(i32* %a, i32 %n) {
+entry:
+  br label %loop
+loop:
+  %i = phi i32 [ 0, %entry ], [ %i.next, %loop ]
+  %s = phi i32 [ 0, %entry ], [ %s.next, %loop ]
+  %p = getelementptr inbounds i32, i32* %a, i32 %i
+  %v = load i32, i32* %p
+  %s.next = add i32 %s, %v
+  %i.next = add nsw i32 %i, 1
+  %c = icmp slt i32 %i.next, %n
+  br i1 %c, label %loop, label %exit
+exit:
+  ret i32 %s
+}
+
+; sea-instcombine is in the -O2 pipeline -> urem survives, no power-of-2 and
+; CHECK: urem i32 %x, 8
+; CHECK-NOT: and i32 %x, 7
+;
+; non-vacuity: stock -O2 folds urem-by-pow2 to and
+; STOCK: and i32 %x, 7


### PR DESCRIPTION
Run the full SeaHorn -O2 pipeline (PassManagerBuilder). Asserts sea-instcombine is engaged (urem-by-pow2 survives, stock -O2 folds to and), and drives the sea loop passes over a loop with a verifier check on the output. The loop passes have no assertable behavioral divergence on LLVM 14, so this is their smoke/ verify coverage (catches crashes / malformed IR during the port).